### PR TITLE
Updated New docker that takes base + toolchain

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,7 @@
-FROM ubuntu:18.04
+FROM nztech/codelite_cc:base_14.0
 LABEL maintainer="cole@nztech.ca"
 
-#setup install prereq and install latest codelite
-RUN apt-get update && apt-get upgrade -y
-RUN apt-get install -y gnupg software-properties-common sudo git make
-RUN apt-key adv --fetch-keys http://repos.codelite.org/CodeLite.asc \
-&& apt-add-repository 'deb https://repos.codelite.org/ubuntu/ bionic universe'
-RUN apt-get update && apt-get install -y codelite
+#copy over the two folders
+COPY raspi-sysroot /home/nztech/raspi
 
-#add user can switch to another user, replace nztech with choice of name
-RUN groupadd -g 1000 nztech
-RUN useradd -d /home/nztech -s /bin/bash -m nztech -u 1000 -g 1000
-USER nztech
-
-#set start and launch codelite, again replace nztech with above defined user
-ENV HOME /home/nztech
 CMD ["/usr/bin/codelite"]


### PR DESCRIPTION
using the prebuilt image from the master branch, and add the sysroot folder
The folder should include raspi-syroot/sysroot and raspi-sysroot/tools
where tools are the toolchain and sysroot should include any needed libraries